### PR TITLE
New ontologies for Bgee - mammals

### DIFF
--- a/src/cfamdv/cfamdv.obo
+++ b/src/cfamdv/cfamdv.obo
@@ -1,0 +1,178 @@
+format-version: 1.2
+date: 19:06:2016 14:23
+saved-by: ame
+default-namespace: dog_stages_ontology
+subsetdef: granular_stage "Subset consisting of classes describing highly granular developmental stages (for instance, '23-year-old'). Such stages might be useful for annotation purpose, but might be folded into less granular parents for display purpose."
+ontology: cfamdv
+
+[Term]
+id: CfamDv:0000000
+name: dog life cycle stage
+def: "A spatiotemporal region encompassing some part of the life cycle of an organism." [UBERON:0000105]
+synonym: "developmental stage" EXACT []
+synonym: "stage" NARROW []
+xref: UBERON:0000105
+
+[Term]
+id: CfamDv:0000001
+name: dog life cycle
+namespace: dog_developmental_stage
+def: "Temporal interval that defines dog life from the prenatal stage until late adult stage." [Bgee:curator "Bgee"]
+xref: UBERON:0000104
+is_a: CfamDv:0000000 ! dog life cycle stage
+
+[Term]
+id: CfamDv:0000002
+name: prenatal stage
+namespace: dog_developmental_stage
+def: "dog life cycle that starts with fertilization and ends with birth" [Bgee:curator "Bgee"]
+comment: estimated gestation time of 63 days (http://genomics.senescence.info/species/entry.php?species=Canis_familiaris)
+xref: UBERON:0000068
+is_a: CfamDv:0000000 ! dog life cycle stage
+relationship: part_of CfamDv:0000001 ! dog life cycle
+property_value: start_dpf "0.0" xsd:float
+property_value: end_dpf "63.0" xsd:float
+
+[Term]
+id: CfamDv:0000003
+name: immature stage
+namespace: dog_developmental_stage
+def: "dog developmental stage that covers the period from birth to 510 days, when individuals usually reach sexual maturity." [Bgee:curator "Bgee"]
+comment: male and female dog reach maturity at 510 days of age (http://genomics.senescence.info/species/entry.php?species=Canis_familiaris).
+xref: UBERON:0000112
+is_a: CfamDv:0000000 ! dog life cycle stage
+relationship: part_of CfamDv:0000001 ! dog life cycle
+relationship: immediately_preceded_by CfamDv:0000002 ! prenatal stage
+property_value: start_dpf "63.0" xsd:float
+property_value: start_mpb "0.0" xsd:float
+property_value: end_mpb "17.0" xsd:float
+
+[Term]
+id: CfamDv:0000004
+name: mature stage
+namespace: dog_developmental_stage
+synonym: "mature" EXACT []
+def: "dog developmental stage that refers to a sexually mature adult dog, which is over about 510 days" [Bgee:curator "Bgee"]
+comment: Male and female dog reach sexual maturity by 510 days of age (http://genomics.senescence.info/species/entry.php?species=Canis_familiaris).
+xref: UBERON:0000113
+is_a: CfamDv:0000000 ! dog life cycle stage
+relationship: part_of CfamDv:0000001 ! dog life cycle
+relationship: immediately_preceded_by CfamDv:0000003 ! immature stage
+property_value: start_mpb "17.0" xsd:float
+
+[Term]
+id: CfamDv:0000005
+name: adulthood stage
+namespace: dog_developmental_stage
+def: "Mature stage that refers to a adult dog which is over 510 days, lower bound age of sexual maturity, and under 6 years, lower bound of senior age." [Bgee:curator "Bgee"]
+comment: Note that adulthood in dogs is very heterogenous, depending on factors such as the size and/or the breed. Ref: http://www.lowchensaustralia.com/breeding/pupstages.htm; http://www.petplace.com/article/dogs/keeping-your-dog-healthy/senior-dog-care/when-is-a-dog-considered-senior.
+synonym: "prime adult stage" EXACT []
+xref: UBERON:0018241
+is_a: CfamDv:0000000 ! dog life cycle stage
+relationship: part_of CfamDv:0000004 ! mature stage
+property_value: start_mpb "17.0" xsd:float
+property_value: end_mpb "72.0" xsd:float
+property_value: end_ypb "6.0" xsd:float
+
+[Term]
+id: CfamDv:0000006
+name: aged stage
+namespace: dog_developmental_stage
+def: "Mature stage that refers to a adult dog which is over 6 years." [Bgee:curator "Bgee"]
+comment: There is little information on the longevity of dogs, and depends on factors such as the size and/or the breed. Maximum ongevity in captivity has been reported to 24 years. 
+xref: UBERON:0007222
+is_a: CfamDv:0000000 ! dog life cycle stage
+relationship: part_of CfamDv:0000004 ! mature stage
+relationship: immediately_preceded_by CfamDv:0000005 ! adulthood stage
+property_value: start_mpb "72.0" xsd:float
+property_value: start_ypb "6.0" xsd:float
+
+[Typedef]
+id: part_of
+name: part of
+xref: BFO:0000050
+is_transitive: true
+
+[Typedef]
+id: preceded_by
+name: preceded_by
+def: "X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)" []
+xref: BFO:0000062
+is_transitive: true
+
+[Typedef]
+id: immediately_preceded_by
+name: immediately_preceded_by
+def: "X immediately_preceded_by Y iff: end(X) simultaneous_with start(Y)" []
+is_a: preceded_by ! preceded_by
+xref: RO:0002087 ! immediately_preceded_by
+
+[Typedef]
+id: has_unit
+name: has unit
+is_metadata_tag: true
+comment: Used to associate a measurement property (e.g. days post fertilization) with a unit (e.g. days)
+
+[Typedef]
+id: has_start_time
+name: has start time
+is_metadata_tag: true
+
+[Typedef]
+id: has_end_time
+name: has end time
+is_metadata_tag: true
+
+[Typedef]
+id: start_dpf
+name: start, days post fertilization
+def: "Count of number of days intervening between the start of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 0 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_start_time
+
+[Typedef]
+id: end_dpf
+name: end, days post fertilization
+def: "Count of number of days intervening between the end of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 1 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_end_time
+
+[Typedef]
+id: start_mpb
+name: start, months post birth
+def: "Count of number of months intervening between the start of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 0 for this property, and the period during which the child is one month old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_start_time
+
+[Typedef]
+id: end_mpb
+name: end, months post birth
+def: "Count of number of months intervening between the end of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 1 for this property, and the period during which the child is one month old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_end_time
+
+[Typedef]
+id: start_ypb
+name: start, years post birth
+def: "Count of number of years intervening between the start of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 0 for this property, and the period during which the child is one year old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_start_time
+
+[Typedef]
+id: end_ypb
+name: end, years post birth
+def: "Count of number of years intervening between the end of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 1 for this property, and the period during which the child is one year old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_end_time

--- a/src/cpordv/cpordv.obo
+++ b/src/cpordv/cpordv.obo
@@ -1,0 +1,158 @@
+format-version: 1.2
+date: 19:06:2016 14:23
+saved-by: ame
+default-namespace: cavy_stages_ontology
+subsetdef: granular_stage "Subset consisting of classes describing highly granular developmental stages (for instance, '23-year-old'). Such stages might be useful for annotation purpose, but might be folded into less granular parents for display purpose."
+ontology: cpordv
+
+[Term]
+id: CporDv:0000000
+name: cavy life cycle stage
+def: "A spatiotemporal region encompassing some part of the life cycle of an organism." [UBERON:0000105]
+synonym: "developmental stage" EXACT []
+synonym: "stage" NARROW []
+xref: UBERON:0000105
+
+[Term]
+id: CporDv:0000001
+name: cavy life cycle
+namespace: cavy_developmental_stage
+def: "Temporal interval that defines cavy life from the prenatal stage until late adult stage." [Bgee:curator "Bgee"]
+xref: UBERON:0000104
+is_a: CporDv:0000000 ! cavy life cycle stage
+
+[Term]
+id: CporDv:0000002
+name: prenatal stage
+namespace: cavy_developmental_stage
+def: "cavy life cycle that starts with fertilization and ends with birth" [Bgee:curator "Bgee"]
+comment: estimated gestation period is 68 days (http://genomics.senescence.info/species/entry.php?species=Cavia_porcellus).
+xref: UBERON:0000068
+is_a: CporDv:0000000 ! cavy life cycle stage
+relationship: part_of CporDv:0000001 ! cavy life cycle
+property_value: start_dpf "0.0" xsd:float
+property_value: end_dpf "68.0" xsd:float
+
+[Term]
+id: CporDv:0000003
+name: immature stage
+namespace: cavy_developmental_stage
+def: "cavy developmental stage that covers the period from birth until 71 days old, when individuals usually reach sexual maturity." [Bgee:curator "Bgee"]
+comment: Male and female cavy reach sexual maturity in different ages: 66 days post-birth for females and 76 days post birth for males (http://genomics.senescence.info/species/entry.php?species=Cavia_porcellus). Thus, we arbitrary set the boundary between immature and mature stages to 71 days old (mean value of male and female maturity).
+xref: UBERON:0000112
+is_a: CporDv:0000000 ! cavy life cycle stage
+relationship: part_of CporDv:0000001 ! cavy life cycle
+relationship: immediately_preceded_by CporDv:0000002 ! prenatal stage
+property_value: start_dpf "68.0" xsd:float
+property_value: start_mpb "0.0" xsd:float
+property_value: end_mpb "2.3" xsd:float
+
+[Term]
+id: CporDv:0000004
+name: mature stage
+namespace: cavy_developmental_stage
+synonym: "mature" EXACT []
+def: "cavy developmental stage that refers to a sexually mature adult cavy, which is over about 71 days old." [Bgee:curator "Bgee"]
+comment: Male and female cavy reach sexual maturity in different ages: 66 days post-birth for females and 76 days post birth for males (http://genomics.senescence.info/species/entry.php?species=Cavia_porcellus). Thus, we arbitrary set the boundary between immature and mature stages to 71 days old (mean value of male and female maturity).
+xref: UBERON:0000113
+is_a: CporDv:0000000 ! cavy life cycle stage
+relationship: part_of CporDv:0000001 ! cavy life cycle
+relationship: immediately_preceded_by CporDv:0000003 ! immature stage
+property_value: start_mpb "2.3" xsd:float
+
+[Term]
+id: CporDv:0000005
+name: adulthood stage
+namespace: cavy_developmental_stage
+def: "Mature stage that refers to a adult cavy which is over 71 days and under 2 years: these bounds are defined by sexual maturity of cavys used for commercial breeding." [Bgee:curator "Bgee"]
+comment: ref https://embryology.med.unsw.edu.au/embryology/index.php/Guinea_Pig_Development
+synonym: "prime adult stage" EXACT []
+xref: UBERON:0018241
+is_a: CporDv:0000000 ! cavy life cycle stage
+relationship: part_of CporDv:0000004 ! mature stage
+property_value: start_mpb "2.3" xsd:float
+property_value: end_mpb "24.0" xsd:float
+
+[Term]
+id: CporDv:0000006
+name: aged stage
+namespace: cavy_developmental_stage
+def: "Mature stage that refers to a adult cavy which is over 2 years." [Bgee:curator "Bgee"]
+comment: There is little information on the longevity of cavys. They can live up to 12 years in captivity (http://genomics.senescence.info/species/entry.php?species=Cavia_porcellus).
+xref: UBERON:0007222
+is_a: CporDv:0000000 ! cavy life cycle stage
+relationship: part_of CporDv:0000004 ! mature stage
+relationship: immediately_preceded_by CporDv:0000005 ! adulthood stage
+property_value: start_mpb "24.0" xsd:float
+
+[Typedef]
+id: part_of
+name: part of
+xref: BFO:0000050
+is_transitive: true
+
+[Typedef]
+id: preceded_by
+name: preceded_by
+def: "X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)" []
+xref: BFO:0000062
+is_transitive: true
+
+[Typedef]
+id: immediately_preceded_by
+name: immediately_preceded_by
+def: "X immediately_preceded_by Y iff: end(X) simultaneous_with start(Y)" []
+is_a: preceded_by ! preceded_by
+xref: RO:0002087 ! immediately_preceded_by
+
+[Typedef]
+id: has_unit
+name: has unit
+is_metadata_tag: true
+comment: Used to associate a measurement property (e.g. days post fertilization) with a unit (e.g. days)
+
+[Typedef]
+id: has_start_time
+name: has start time
+is_metadata_tag: true
+
+[Typedef]
+id: has_end_time
+name: has end time
+is_metadata_tag: true
+
+[Typedef]
+id: start_dpf
+name: start, days post fertilization
+def: "Count of number of days intervening between the start of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 0 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_start_time
+
+[Typedef]
+id: end_dpf
+name: end, days post fertilization
+def: "Count of number of days intervening between the end of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 1 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_end_time
+
+[Typedef]
+id: start_mpb
+name: start, months post birth
+def: "Count of number of months intervening between the start of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 0 for this property, and the period during which the child is one month old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_start_time
+
+[Typedef]
+id: end_mpb
+name: end, months post birth
+def: "Count of number of months intervening between the end of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 1 for this property, and the period during which the child is one month old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_end_time

--- a/src/ecabdv/ecabdv.obo
+++ b/src/ecabdv/ecabdv.obo
@@ -1,0 +1,181 @@
+format-version: 1.2
+date: 19:06:2016 14:23
+saved-by: ame
+default-namespace: horse_stages_ontology
+subsetdef: granular_stage "Subset consisting of classes describing highly granular developmental stages (for instance, '23-year-old'). Such stages might be useful for annotation purpose, but might be folded into less granular parents for display purpose."
+ontology: ecabdv
+
+[Term]
+id: EcabDv:0000000
+name: horse life cycle stage
+def: "A spatiotemporal region encompassing some part of the life cycle of an organism." [UBERON:0000105]
+synonym: "developmental stage" EXACT []
+synonym: "stage" NARROW []
+xref: UBERON:0000105
+
+[Term]
+id: EcabDv:0000001
+name: horse life cycle
+namespace: horse_developmental_stage
+def: "Temporal interval that defines horse life from the prenatal stage until late adult stage." [Bgee:curator "Bgee"]
+xref: UBERON:0000104
+is_a: EcabDv:0000000 ! horse life cycle stage
+
+[Term]
+id: EcabDv:0000002
+name: prenatal stage
+namespace: horse_developmental_stage
+def: "horse life cycle that starts with fertilization and ends with birth" [Bgee:curator "Bgee"]
+comment: estimated gestation period is 337 days (http://genomics.senescence.info/species/entry.php?species=Equus_caballus).
+xref: UBERON:0000068
+is_a: EcabDv:0000000 ! horse life cycle stage
+relationship: part_of EcabDv:0000001 ! horse life cycle
+property_value: start_dpf "0.0" xsd:float
+property_value: end_dpf "337.0" xsd:float
+
+[Term]
+id: EcabDv:0000003
+name: immature stage
+namespace: horse_developmental_stage
+def: "horse developmental stage that covers the period from birth until 943 days old, when individuals usually reach sexual maturity." [Bgee:curator "Bgee"]
+comment: Male and female horse reach sexual maturity in different ages: 973 days post-birth for females and 914 days post birth for males (http://genomics.senescence.info/species/entry.php?species=Equus_caballus). Thus, we arbitrary set the boundary between immature and mature stages to 943 days old, i.e. 2.6 years (mean value of male and female maturity).
+xref: UBERON:0000112
+is_a: EcabDv:0000000 ! horse life cycle stage
+relationship: part_of EcabDv:0000001 ! horse life cycle
+relationship: immediately_preceded_by EcabDv:0000002 ! prenatal stage
+property_value: start_dpf "337.0" xsd:float
+property_value: start_mpb "0.0" xsd:float
+property_value: end_mpb "31.4" xsd:float
+property_value: end_ypb "2.6" xsd:float
+
+[Term]
+id: EcabDv:0000004
+name: mature stage
+namespace: horse_developmental_stage
+synonym: "mature" EXACT []
+def: "horse developmental stage that refers to a sexually mature adult horse, which is over about 943 days old." [Bgee:curator "Bgee"]
+comment: Male and female horse reach sexual maturity in different ages: 973 days post-birth for females and 914 days post birth for males (http://genomics.senescence.info/species/entry.php?species=Equus_caballus). Thus, we arbitrary set the boundary between immature and mature stages to 943 days old, i.e. 2.6 years (mean value of male and female maturity).
+xref: UBERON:0000113
+is_a: EcabDv:0000000 ! horse life cycle stage
+relationship: part_of EcabDv:0000001 ! horse life cycle
+relationship: immediately_preceded_by EcabDv:0000003 ! immature stage
+property_value: start_mpb "31.4" xsd:float
+property_value: start_ypb "2.6" xsd:float
+
+[Term]
+id: EcabDv:0000005
+name: adulthood stage
+namespace: horse_developmental_stage
+def: "Mature stage that refers to a adult horse which is over 943 days old, lower bound of adulthood, and under 20 years, lower bound of senior age." [Bgee:curator "Bgee"]
+comment: Note that adulthood in horses is very heterogenous, depending on factors such as the size and/or the breed. Ref: http://www.dspca.ie/BasicEquineCare
+synonym: "prime adult stage" EXACT []
+xref: UBERON:0018241
+is_a: EcabDv:0000000 ! horse life cycle stage
+relationship: part_of EcabDv:0000004 ! mature stage
+property_value: start_mpb "31.4" xsd:float
+property_value: start_ypb "2.6" xsd:float
+property_value: end_mpb "240.0" xsd:float
+property_value: end_ypb "20.0" xsd:float
+
+[Term]
+id: EcabDv:0000006
+name: aged stage
+namespace: horse_developmental_stage
+def: "Mature stage that refers to a adult horse which is over 20 years." [Bgee:curator "Bgee"]
+comment: There is little information on the longevity of horses. They can live up to 57 years in captivity (http://genomics.senescence.info/species/entry.php?species=Equus_caballus).
+xref: UBERON:0007222
+is_a: EcabDv:0000000 ! horse life cycle stage
+relationship: part_of EcabDv:0000004 ! mature stage
+relationship: immediately_preceded_by EcabDv:0000005 ! adulthood stage
+property_value: start_mpb "240.0" xsd:float
+property_value: start_ypb "20.0" xsd:float
+
+[Typedef]
+id: part_of
+name: part of
+xref: BFO:0000050
+is_transitive: true
+
+[Typedef]
+id: preceded_by
+name: preceded_by
+def: "X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)" []
+xref: BFO:0000062
+is_transitive: true
+
+[Typedef]
+id: immediately_preceded_by
+name: immediately_preceded_by
+def: "X immediately_preceded_by Y iff: end(X) simultaneous_with start(Y)" []
+is_a: preceded_by ! preceded_by
+xref: RO:0002087 ! immediately_preceded_by
+
+[Typedef]
+id: has_unit
+name: has unit
+is_metadata_tag: true
+comment: Used to associate a measurement property (e.g. days post fertilization) with a unit (e.g. days)
+
+[Typedef]
+id: has_start_time
+name: has start time
+is_metadata_tag: true
+
+[Typedef]
+id: has_end_time
+name: has end time
+is_metadata_tag: true
+
+[Typedef]
+id: start_dpf
+name: start, days post fertilization
+def: "Count of number of days intervening between the start of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 0 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_start_time
+
+[Typedef]
+id: end_dpf
+name: end, days post fertilization
+def: "Count of number of days intervening between the end of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 1 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_end_time
+
+[Typedef]
+id: start_mpb
+name: start, months post birth
+def: "Count of number of months intervening between the start of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 0 for this property, and the period during which the child is one month old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_start_time
+
+[Typedef]
+id: end_mpb
+name: end, months post birth
+def: "Count of number of months intervening between the end of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 1 for this property, and the period during which the child is one month old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_end_time
+
+[Typedef]
+id: start_ypb
+name: start, years post birth
+def: "Count of number of years intervening between the start of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 0 for this property, and the period during which the child is one year old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_start_time
+
+[Typedef]
+id: end_ypb
+name: end, years post birth
+def: "Count of number of years intervening between the end of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 1 for this property, and the period during which the child is one year old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_end_time

--- a/src/eeurdv/eeurdv.obo
+++ b/src/eeurdv/eeurdv.obo
@@ -1,0 +1,158 @@
+format-version: 1.2
+date: 19:06:2016 14:23
+saved-by: ame
+default-namespace: hedgehog_stages_ontology
+subsetdef: granular_stage "Subset consisting of classes describing highly granular developmental stages (for instance, '23-year-old'). Such stages might be useful for annotation purpose, but might be folded into less granular parents for display purpose."
+ontology: eeurdv
+
+[Term]
+id: EeurDv:0000000
+name: hedgehog life cycle stage
+def: "A spatiotemporal region encompassing some part of the life cycle of an organism." [UBERON:0000105]
+synonym: "developmental stage" EXACT []
+synonym: "stage" NARROW []
+xref: UBERON:0000105
+
+[Term]
+id: EeurDv:0000001
+name: hedgehog life cycle
+namespace: hedgehog_developmental_stage
+def: "Temporal interval that defines hedgehog life from the prenatal stage until late adult stage." [Bgee:curator "Bgee"]
+xref: UBERON:0000104
+is_a: EeurDv:0000000 ! hedgehog life cycle stage
+
+[Term]
+id: EeurDv:0000002
+name: prenatal stage
+namespace: hedgehog_developmental_stage
+def: "hedgehog life cycle that starts with fertilization and ends with birth" [Bgee:curator "Bgee"]
+comment: estimated gestation period is 30 days (http://genomics.senescence.info/species/entry.php?species=Erinaceus_europaeus).
+xref: UBERON:0000068
+is_a: EeurDv:0000000 ! hedgehog life cycle stage
+relationship: part_of EeurDv:0000001 ! hedgehog life cycle
+property_value: start_dpf "0.0" xsd:float
+property_value: end_dpf "30.0" xsd:float
+
+[Term]
+id: EeurDv:0000003
+name: immature stage
+namespace: hedgehog_developmental_stage
+def: "hedgehog developmental stage that covers the period from birth until 253 days old, when individuals usually reach sexual maturity." [Bgee:curator "Bgee"]
+comment: (http://genomics.senescence.info/species/entry.php?species=Erinaceus_europaeus).
+xref: UBERON:0000112
+is_a: EeurDv:0000000 ! hedgehog life cycle stage
+relationship: part_of EeurDv:0000001 ! hedgehog life cycle
+relationship: immediately_preceded_by EeurDv:0000002 ! prenatal stage
+property_value: start_dpf "30.0" xsd:float
+property_value: start_mpb "0.0" xsd:float
+property_value: end_mpb "8.4" xsd:float
+
+[Term]
+id: EeurDv:0000004
+name: mature stage
+namespace: hedgehog_developmental_stage
+synonym: "mature" EXACT []
+def: "hedgehog developmental stage that refers to a sexually mature adult hedgehog, which is over about 253 days old." [Bgee:curator "Bgee"]
+comment: (http://genomics.senescence.info/species/entry.php?species=Erinaceus_europaeus).
+xref: UBERON:0000113
+is_a: EeurDv:0000000 ! hedgehog life cycle stage
+relationship: part_of EeurDv:0000001 ! hedgehog life cycle
+relationship: immediately_preceded_by EeurDv:0000003 ! immature stage
+property_value: start_mpb "8.4" xsd:float
+
+[Term]
+id: EeurDv:0000005
+name: adulthood stage
+namespace: hedgehog_developmental_stage
+def: "Mature stage that refers to a adult hedgehog which is over 253 days old, lower bound age of sexual maturity, and under 5 years, upper bound before old age." [Bgee:curator "Bgee"]
+comment: Data are come from observation in the wild. Ref: http://wildpro.twycrosszoo.org/S/0MInsectivor/Erinaceidae/Erinaceus/Erinaceus_europaeus/07WEHLifePhys.htm.
+synonym: "prime adult stage" EXACT []
+xref: UBERON:0018241
+is_a: EeurDv:0000000 ! hedgehog life cycle stage
+relationship: part_of EeurDv:0000004 ! mature stage
+property_value: start_mpb "8.4" xsd:float
+property_value: end_mpb "60.0" xsd:float
+
+[Term]
+id: EeurDv:0000006
+name: aged stage
+namespace: hedgehog_developmental_stage
+def: "Mature stage that refers to a adult hedgehog which is over 60 months old." [Bgee:curator "Bgee"]
+comment: There is little information on the longevity of hedgehogs. They can live up to 12 years in captivity (http://genomics.senescence.info/species/entry.php?species=Erinaceus_europaeus).
+xref: UBERON:0007222
+is_a: EeurDv:0000000 ! hedgehog life cycle stage
+relationship: part_of EeurDv:0000004 ! mature stage
+relationship: immediately_preceded_by EeurDv:0000005 ! adulthood stage
+property_value: start_mpb "60.0" xsd:float
+
+[Typedef]
+id: part_of
+name: part of
+xref: BFO:0000050
+is_transitive: true
+
+[Typedef]
+id: preceded_by
+name: preceded_by
+def: "X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)" []
+xref: BFO:0000062
+is_transitive: true
+
+[Typedef]
+id: immediately_preceded_by
+name: immediately_preceded_by
+def: "X immediately_preceded_by Y iff: end(X) simultaneous_with start(Y)" []
+is_a: preceded_by ! preceded_by
+xref: RO:0002087 ! immediately_preceded_by
+
+[Typedef]
+id: has_unit
+name: has unit
+is_metadata_tag: true
+comment: Used to associate a measurement property (e.g. days post fertilization) with a unit (e.g. days)
+
+[Typedef]
+id: has_start_time
+name: has start time
+is_metadata_tag: true
+
+[Typedef]
+id: has_end_time
+name: has end time
+is_metadata_tag: true
+
+[Typedef]
+id: start_dpf
+name: start, days post fertilization
+def: "Count of number of days intervening between the start of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 0 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_start_time
+
+[Typedef]
+id: end_dpf
+name: end, days post fertilization
+def: "Count of number of days intervening between the end of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 1 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_end_time
+
+[Typedef]
+id: start_mpb
+name: start, months post birth
+def: "Count of number of months intervening between the start of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 0 for this property, and the period during which the child is one month old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_start_time
+
+[Typedef]
+id: end_mpb
+name: end, months post birth
+def: "Count of number of months intervening between the end of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 1 for this property, and the period during which the child is one month old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_end_time

--- a/src/fcatdv/fcatdv.obo
+++ b/src/fcatdv/fcatdv.obo
@@ -1,0 +1,178 @@
+format-version: 1.2
+date: 19:06:2016 14:23
+saved-by: ame
+default-namespace: cat_stages_ontology
+subsetdef: granular_stage "Subset consisting of classes describing highly granular developmental stages (for instance, '23-year-old'). Such stages might be useful for annotation purpose, but might be folded into less granular parents for display purpose."
+ontology: fcatdv
+
+[Term]
+id: FcatDv:0000000
+name: cat life cycle stage
+def: "A spatiotemporal region encompassing some part of the life cycle of an organism." [UBERON:0000105]
+synonym: "developmental stage" EXACT []
+synonym: "stage" NARROW []
+xref: UBERON:0000105
+
+[Term]
+id: FcatDv:0000001
+name: cat life cycle
+namespace: cat_developmental_stage
+def: "Temporal interval that defines cat life from the prenatal stage until late adult stage." [Bgee:curator "Bgee"]
+xref: UBERON:0000104
+is_a: FcatDv:0000000 ! cat life cycle stage
+
+[Term]
+id: FcatDv:0000002
+name: prenatal stage
+namespace: cat_developmental_stage
+def: "cat life cycle that starts with fertilization and ends with birth" [Bgee:curator "Bgee"]
+comment: estimated gestation period is 65 days (http://genomics.senescence.info/species/entry.php?species=Felis_catus).
+xref: UBERON:0000068
+is_a: FcatDv:0000000 ! cat life cycle stage
+relationship: part_of FcatDv:0000001 ! cat life cycle
+property_value: start_dpf "0.0" xsd:float
+property_value: end_dpf "65.0" xsd:float
+
+[Term]
+id: FcatDv:0000003
+name: immature stage
+namespace: cat_developmental_stage
+def: "cat developmental stage that covers the period from birth until 289 days old when individuals usually reach sexual maturity." [Bgee:curator "Bgee"]
+comment: (http://genomics.senescence.info/species/entry.php?species=Felis_catus).
+xref: UBERON:0000112
+is_a: FcatDv:0000000 ! cat life cycle stage
+relationship: part_of FcatDv:0000001 ! cat life cycle
+relationship: immediately_preceded_by FcatDv:0000002 ! prenatal stage
+property_value: start_dpf "65.0" xsd:float
+property_value: start_mpb "0.0" xsd:float
+property_value: end_mpb "9.6" xsd:float
+
+[Term]
+id: FcatDv:0000004
+name: mature stage
+namespace: cat_developmental_stage
+synonym: "mature" EXACT []
+def: "cat developmental stage that refers to a sexually mature adult cat, which is over about 289 days old." [Bgee:curator "Bgee"]
+comment: (http://genomics.senescence.info/species/entry.php?species=Felis_catus).
+xref: UBERON:0000113
+is_a: FcatDv:0000000 ! cat life cycle stage
+relationship: part_of FcatDv:0000001 ! cat life cycle
+relationship: immediately_preceded_by FcatDv:0000003 ! immature stage
+property_value: start_mpb "9.6" xsd:float
+
+[Term]
+id: FcatDv:0000005
+name: adulthood stage
+namespace: cat_developmental_stage
+def: "Mature stage that refers to a adult cat which is over 289 days old, lower bound of adulthood, and under 10 years, lower bound of senior age." [Bgee:curator "Bgee"]
+comment: Note that adulthood in cats is very heterogenous, depending on factors such as the size and/or the breed. Ref: http://icatcare.org/advice/life-stages
+synonym: "prime adult stage" EXACT []
+xref: UBERON:0018241
+is_a: FcatDv:0000000 ! cat life cycle stage
+relationship: part_of FcatDv:0000004 ! mature stage
+property_value: start_mpb "9.6" xsd:float
+property_value: end_mpb "120.0" xsd:float
+property_value: end_ypb "10.0" xsd:float
+
+[Term]
+id: FcatDv:0000006
+name: aged stage
+namespace: cat_developmental_stage
+def: "Mature stage that refers to a adult cat which is over 10 years." [Bgee:curator "Bgee"]
+comment: There is little information on the longevity of cats. They can live up to 30 years in captivity (http://genomics.senescence.info/species/entry.php?species=Felis_catus).
+xref: UBERON:0007222
+is_a: FcatDv:0000000 ! cat life cycle stage
+relationship: part_of FcatDv:0000004 ! mature stage
+relationship: immediately_preceded_by FcatDv:0000005 ! adulthood stage
+property_value: start_mpb "120.0" xsd:float
+property_value: start_ypb "10.0" xsd:float
+
+[Typedef]
+id: part_of
+name: part of
+xref: BFO:0000050
+is_transitive: true
+
+[Typedef]
+id: preceded_by
+name: preceded_by
+def: "X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)" []
+xref: BFO:0000062
+is_transitive: true
+
+[Typedef]
+id: immediately_preceded_by
+name: immediately_preceded_by
+def: "X immediately_preceded_by Y iff: end(X) simultaneous_with start(Y)" []
+is_a: preceded_by ! preceded_by
+xref: RO:0002087 ! immediately_preceded_by
+
+[Typedef]
+id: has_unit
+name: has unit
+is_metadata_tag: true
+comment: Used to associate a measurement property (e.g. days post fertilization) with a unit (e.g. days)
+
+[Typedef]
+id: has_start_time
+name: has start time
+is_metadata_tag: true
+
+[Typedef]
+id: has_end_time
+name: has end time
+is_metadata_tag: true
+
+[Typedef]
+id: start_dpf
+name: start, days post fertilization
+def: "Count of number of days intervening between the start of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 0 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_start_time
+
+[Typedef]
+id: end_dpf
+name: end, days post fertilization
+def: "Count of number of days intervening between the end of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 1 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_end_time
+
+[Typedef]
+id: start_mpb
+name: start, months post birth
+def: "Count of number of months intervening between the start of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 0 for this property, and the period during which the child is one month old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_start_time
+
+[Typedef]
+id: end_mpb
+name: end, months post birth
+def: "Count of number of months intervening between the end of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 1 for this property, and the period during which the child is one month old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_end_time
+
+[Typedef]
+id: start_ypb
+name: start, years post birth
+def: "Count of number of years intervening between the start of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 0 for this property, and the period during which the child is one year old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_start_time
+
+[Typedef]
+id: end_ypb
+name: end, years post birth
+def: "Count of number of years intervening between the end of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 1 for this property, and the period during which the child is one year old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_end_time

--- a/src/ocundv/ocundv.obo
+++ b/src/ocundv/ocundv.obo
@@ -1,0 +1,178 @@
+format-version: 1.2
+date: 19:06:2016 14:23
+saved-by: ame
+default-namespace: rabbit_stages_ontology
+subsetdef: granular_stage "Subset consisting of classes describing highly granular developmental stages (for instance, '23-year-old'). Such stages might be useful for annotation purpose, but might be folded into less granular parents for display purpose."
+ontology: ocundv
+
+[Term]
+id: OcunDv:0000000
+name: rabbit life cycle stage
+def: "A spatiotemporal region encompassing some part of the life cycle of an organism." [UBERON:0000105]
+synonym: "developmental stage" EXACT []
+synonym: "stage" NARROW []
+xref: UBERON:0000105
+
+[Term]
+id: OcunDv:0000001
+name: rabbit life cycle
+namespace: rabbit_developmental_stage
+def: "Temporal interval that defines rabbit life from the prenatal stage until late adult stage." [Bgee:curator "Bgee"]
+xref: UBERON:0000104
+is_a: OcunDv:0000000 ! rabbit life cycle stage
+
+[Term]
+id: OcunDv:0000002
+name: prenatal stage
+namespace: rabbit_developmental_stage
+def: "rabbit life cycle that starts with fertilization and ends with birth" [Bgee:curator "Bgee"]
+comment: estimated gestation period is 30 days (http://genomics.senescence.info/species/entry.php?species=Oryctolagus_cuninculus).
+xref: UBERON:0000068
+is_a: OcunDv:0000000 ! rabbit life cycle stage
+relationship: part_of OcunDv:0000001 ! rabbit life cycle
+property_value: start_dpf "0.0" xsd:float
+property_value: end_dpf "30.0" xsd:float
+
+[Term]
+id: OcunDv:0000003
+name: immature stage
+namespace: rabbit_developmental_stage
+def: "rabbit developmental stage that covers the period from birth until 730 days old, when individuals usually reach sexual maturity." [Bgee:curator "Bgee"]
+comment: (http://genomics.senescence.info/species/entry.php?species=Oryctolagus_cuninculus).
+xref: UBERON:0000112
+is_a: OcunDv:0000000 ! rabbit life cycle stage
+relationship: part_of OcunDv:0000001 ! rabbit life cycle
+relationship: immediately_preceded_by OcunDv:0000002 ! prenatal stage
+property_value: start_dpf "30.0" xsd:float
+property_value: start_mpb "0.0" xsd:float
+property_value: end_mpb "24.3" xsd:float
+
+[Term]
+id: OcunDv:0000004
+name: mature stage
+namespace: rabbit_developmental_stage
+synonym: "mature" EXACT []
+def: "rabbit developmental stage that refers to a sexually mature adult rabbit, which is over about 2 years old." [Bgee:curator "Bgee"]
+comment: (http://genomics.senescence.info/species/entry.php?species=Oryctolagus_cuninculus).
+xref: UBERON:0000113
+is_a: OcunDv:0000000 ! rabbit life cycle stage
+relationship: part_of OcunDv:0000001 ! rabbit life cycle
+relationship: immediately_preceded_by OcunDv:0000003 ! immature stage
+property_value: start_mpb "24.3" xsd:float
+
+[Term]
+id: OcunDv:0000005
+name: adulthood stage
+namespace: rabbit_developmental_stage
+def: "Mature stage that refers to a adult rabbit which is over 2 years, lower bound of adulthood, and under 6 years, lower bound of senior age." [Bgee:curator "Bgee"]
+comment: Ref: http://www.melbournerabbitclinic.com/wordpress/?page_id=488
+synonym: "prime adult stage" EXACT []
+xref: UBERON:0018241
+is_a: OcunDv:0000000 ! rabbit life cycle stage
+relationship: part_of OcunDv:0000004 ! mature stage
+property_value: start_mpb "24.3" xsd:float
+property_value: end_mpb "72.0" xsd:float
+property_value: end_ypb "6.0" xsd:float
+
+[Term]
+id: OcunDv:0000006
+name: aged stage
+namespace: rabbit_developmental_stage
+def: "Mature stage that refers to a adult rabbit which is over 6 years." [Bgee:curator "Bgee"]
+comment: There is little information on the longevity of rabbits. They can live up to 12 years in captivity (http://genomics.senescence.info/species/entry.php?species=Oryctolagus_cuninculus).
+xref: UBERON:0007222
+is_a: OcunDv:0000000 ! rabbit life cycle stage
+relationship: part_of OcunDv:0000004 ! mature stage
+relationship: immediately_preceded_by OcunDv:0000005 ! adulthood stage
+property_value: start_mpb "72.0" xsd:float
+property_value: start_ypb "6.0" xsd:float
+
+[Typedef]
+id: part_of
+name: part of
+xref: BFO:0000050
+is_transitive: true
+
+[Typedef]
+id: preceded_by
+name: preceded_by
+def: "X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)" []
+xref: BFO:0000062
+is_transitive: true
+
+[Typedef]
+id: immediately_preceded_by
+name: immediately_preceded_by
+def: "X immediately_preceded_by Y iff: end(X) simultaneous_with start(Y)" []
+is_a: preceded_by ! preceded_by
+xref: RO:0002087 ! immediately_preceded_by
+
+[Typedef]
+id: has_unit
+name: has unit
+is_metadata_tag: true
+comment: Used to associate a measurement property (e.g. days post fertilization) with a unit (e.g. days)
+
+[Typedef]
+id: has_start_time
+name: has start time
+is_metadata_tag: true
+
+[Typedef]
+id: has_end_time
+name: has end time
+is_metadata_tag: true
+
+[Typedef]
+id: start_dpf
+name: start, days post fertilization
+def: "Count of number of days intervening between the start of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 0 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be applirabbition-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_start_time
+
+[Typedef]
+id: end_dpf
+name: end, days post fertilization
+def: "Count of number of days intervening between the end of the stage and the time of fertilization according to a reference model. Note that the first day of development has the value of 1 for this property." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be applirabbition-dependent.
+property_value: has_unit UO:0000033 ! day
+is_a: has_end_time
+
+[Typedef]
+id: start_mpb
+name: start, months post birth
+def: "Count of number of months intervening between the start of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 0 for this property, and the period during which the child is one month old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be applirabbition-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_start_time
+
+[Typedef]
+id: end_mpb
+name: end, months post birth
+def: "Count of number of months intervening between the end of the stage and the time of birth according to a reference model. Note that the first month of post-birth development has the value of 1 for this property, and the period during which the child is one month old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be applirabbition-dependent.
+property_value: has_unit UO:0000035 ! month
+is_a: has_end_time
+
+[Typedef]
+id: start_ypb
+name: start, years post birth
+def: "Count of number of years intervening between the start of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 0 for this property, and the period during which the child is one year old has the value 1." []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_start_time
+
+[Typedef]
+id: end_ypb
+name: end, years post birth
+def: "Count of number of years intervening between the end of the stage and the time of birth according to a reference model. Note that the first year of post-birth development has the value of 1 for this property, and the period during which the child is one year old has the value 2" []
+is_metadata_tag: true
+comment: This is a shortcut annotation that can be expanded to an OWL axiom, or to a set of OWL axioms. The exact translation has yet to be determined, and may be application-dependent.
+property_value: has_unit  UO:0000036 ! year
+is_a: has_end_time


### PR DESCRIPTION
Added ontologies for:
- Cavia porcellus - CporDv
- Erinaceus europaeus - EeurDv
- Canis lupus familiaris - CfamDv
- Equus caballus - EcabDv
- Felis catus - FcatDv
- Oryctolagus cuniculus - OcunDv
