### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/external/bgee/dev_stage_ontology.obo
+++ b/external/bgee/dev_stage_ontology.obo
@@ -1691,7 +1691,7 @@ property_value: start_dpf "1.0" xsd:float
 id: GgalDv:0000012
 name: Hamburger Hamilton stage 3 (chicken)
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [http://www.dx.doi.org/10.1002/aja.1001950404]
+def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [https://doi.org/10.1002/aja.1001950404]
 comment: Usually obtained after 12-13 hours of incubation.
 synonym: "HH3" EXACT []
 relationship: part_of UBERON:0000068 ! embryo stage
@@ -1704,7 +1704,7 @@ property_value: start_dpf "1.25" xsd:float
 id: GgalDv:0000013
 name: Hamburger Hamilton stage 4 (chicken)
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [http://www.dx.doi.org/10.1002/aja.1001950404]
+def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [https://doi.org/10.1002/aja.1001950404]
 comment: Usually obtained after 18-19 hours of incubation.
 synonym: "HH4" EXACT []
 relationship: part_of UBERON:0000068 ! embryo stage

--- a/external/bgee/original_dev_stage_ontology.obo
+++ b/external/bgee/original_dev_stage_ontology.obo
@@ -1947,7 +1947,7 @@ property_value: start_dpf "1.0" xsd:float
 id: GgalDv:0000012
 name: Hamburger Hamilton stage 3 (chicken)
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [http://www.dx.doi.org/10.1002/aja.1001950404]
+def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [https://doi.org/10.1002/aja.1001950404]
 comment: Usually obtained after 12-13 hours of incubation.
 synonym: "HH3" EXACT []
 relationship: part_of UBERON:0000068 ! embryo stage
@@ -1959,7 +1959,7 @@ property_value: start_dpf "1.25" xsd:float
 id: GgalDv:0000013
 name: Hamburger Hamilton stage 4 (chicken)
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [http://www.dx.doi.org/10.1002/aja.1001950404]
+def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [https://doi.org/10.1002/aja.1001950404]
 comment: Usually obtained after 18-19 hours of incubation.
 synonym: "HH4" EXACT []
 relationship: part_of UBERON:0000068 ! embryo stage

--- a/src/ggaldv/ggaldv-uberon.obo
+++ b/src/ggaldv/ggaldv-uberon.obo
@@ -86,7 +86,7 @@ property_value: start_dpf "1.0" xsd:float
 id: GgalDv:0000012
 name: Hamburger Hamilton stage 3 (chicken)
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [http://www.dx.doi.org/10.1002/aja.1001950404]
+def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [https://doi.org/10.1002/aja.1001950404]
 comment: Usually obtained after 12-13 hours of incubation.
 synonym: "HH3" EXACT []
 is_a: UBERON:0000105
@@ -100,7 +100,7 @@ property_value: start_dpf "1.25" xsd:float
 id: GgalDv:0000013
 name: Hamburger Hamilton stage 4 (chicken)
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [http://www.dx.doi.org/10.1002/aja.1001950404]
+def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [https://doi.org/10.1002/aja.1001950404]
 comment: Usually obtained after 18-19 hours of incubation.
 synonym: "HH4" EXACT []
 is_a: UBERON:0000105

--- a/src/ggaldv/ggaldv.obo
+++ b/src/ggaldv/ggaldv.obo
@@ -61,7 +61,7 @@ property_value: end_dpf "1.25" xsd:float
 id: GgalDv:0000012
 name: Hamburger Hamilton stage 3
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [http://www.dx.doi.org/10.1002/aja.1001950404 "adapted from"]
+def: "Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible." [https://doi.org/10.1002/aja.1001950404 "adapted from"]
 comment: Usually obtained after 12-13 hours of incubation.
 synonym: "HH3" EXACT []
 is_a: GgalDv:0000000 ! chicken life cycle stage
@@ -73,7 +73,7 @@ property_value: end_dpf "1.5" xsd:float
 id: GgalDv:0000013
 name: Hamburger Hamilton stage 4
 namespace: chicken_developmental_stage
-def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [http://www.dx.doi.org/10.1002/aja.1001950404 "adapted from"]
+def: "Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen's node are present. " [https://doi.org/10.1002/aja.1001950404 "adapted from"]
 comment: Usually obtained after 18-19 hours of incubation.
 synonym: "HH4" EXACT []
 is_a: GgalDv:0000000 ! chicken life cycle stage

--- a/src/ggaldv/ggaldv.owl
+++ b/src/ggaldv/ggaldv.owl
@@ -669,7 +669,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GgalDv_0000012"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prenatal stage on incubation period defined by the intermediate primitive streak, while no primitive groove is visible.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.dx.doi.org/10.1002/aja.1001950404</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://doi.org/10.1002/aja.1001950404</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -697,7 +697,7 @@
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GgalDv_0000013"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prenatal stage on incubation period defined by the definitive primitive streak, about 1.88 mm long. Primitive groove, primitive pir, Hensen&apos;s node are present. </owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.dx.doi.org/10.1002/aja.1001950404</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://doi.org/10.1002/aja.1001950404</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!