### PR TITLE
Ignore xrefs imported from Uberon.

### DIFF
--- a/src/ontology/life-stages.Makefile
+++ b/src/ontology/life-stages.Makefile
@@ -29,6 +29,8 @@ $(COMPONENTSDIR)/%.json: $(COMPONENTSDIR)/%.owl .FORCE
 # Automatically generated from the xrefs
 $(MAPPINGDIR)/life-stages.sssom.tsv: $(SRC) $(ONT_OBO_FILES) | all_robot_plugins
 	$(ROBOT) merge -i $< \
+		 remove $(foreach pfx,$(ONT_PREFIXES),--base-iri http://purl.obolibrary.org/obo/$(pfx)_) \
+		        --axioms external \
 		 sssom:xref-extract --mapping-file $@ -v \
 		                    --map-prefix-to-predicate 'UBERON semapv:crossSpeciesExactMatch' \
 		                    $(foreach pfx,$(ONT_PREFIXES),--prefix '$(pfx): http://purl.obolibrary.org/obo/$(pfx)_')


### PR DESCRIPTION
When creating the SSSOM set (by extracting the cross-references from the ontology), only use the cross-references from the component ontologies, and explicitly ignore the cross-references on Uberon term from the imported life-stages-core module.

Two reasons for that:

(1) The SSLSO mapping set should only contain mappings originating from SSLSO, not any mapping coming from a remote source.

(2) The xrefs on the Uberon terms are in fact coming from SSLSO, since Uberon is now importing the SSLSO mapping set, so importing them back from Uberon is pointless. We basically have a chain that would look like

SSLSO xrefs -> SSLSO mapping set -> Uberon's SSSOM-derived xrefs -> SSLSO mapping set

This would work fine for now, but would cause issue if one of the xrefs in SSLSO needs to change for any reason: the original xref would come back to us through Uberon.

Better to let SSLSO be the sole source of truth for all mappings to Uberon life stage terms. That is already what Uberon's documentation is saying
(https://obophenotype.github.io/uberon/bridges/#bridges-with-uberon).