### PR TITLE
Use RDF/XML rather than OWL Functional Syntax for .owl files.

### DIFF
--- a/src/ontology/life-stages.Makefile
+++ b/src/ontology/life-stages.Makefile
@@ -17,8 +17,7 @@ $(COMPONENTSDIR)/%.owl: $(COMPONENTSDIR)/%.obo .FORCE
 		merge --input $< \
 		annotate \
 		-V $(ONTBASE)/releases/$(VERSION)/$@ --annotation owl:versionInfo $(VERSION) \
-		--ontology-iri $(ONTBASE)/$@ \
-		convert --format ofn --output $@
+		--ontology-iri $(ONTBASE)/$@ --output $@
 .PRECIOUS: $(COMPONENTSDIR)/%.owl
 
 $(COMPONENTSDIR)/%.json: $(COMPONENTSDIR)/%.owl .FORCE


### PR DESCRIPTION
There are apparently some pipelines out there that expect the individual OWL files to be in RDF/XML, and cannot handle OWL Functional Syntax. So we remove the final `convert` step of the pipeline that produces the `.owl` files, to let ROBOT write the files in RDF/XML instead of forcing OWL Functional Syntax.