### PR TITLE
Revise decade definition to include decade begin, end years

### DIFF
--- a/src/ontology/components/hsapdv.obo
+++ b/src/ontology/components/hsapdv.obo
@@ -3303,12 +3303,12 @@ property_value: start_ypb "30.0" xsd:float
 id: HsapDv:0000239
 name: fifth decade stage
 namespace: human_developmental_stage
-def: "Human stage that refers to an individual who is over 40 and under 50 years old." [Bgee:curator]
+def: "Human stage that refers to an individual who is over 40 and less than or equal to 50 years old." [Bgee:curator]
 is_a: HsapDv:0000000 ! life cycle stage
 relationship: immediately_preceded_by HsapDv:0000238 ! fourth decade stage
 relationship: part_of HsapDv:0000267 ! middle aged stage
 property_value: end_ypb "50.0" xsd:float
-property_value: start_ypb "40.0" xsd:float
+property_value: start_ypb "41.0" xsd:float
 
 [Term]
 id: HsapDv:0000240

--- a/src/ontology/components/hsapdv.obo
+++ b/src/ontology/components/hsapdv.obo
@@ -50,7 +50,7 @@ def: "Prenatal stage that starts with fertilization and ends with a fully formed
 comment: By embryo we mean in the sense of up to the 8th week postfertilization (over 7 and under 8 weeks), we treat fetus as a separate stage.
 synonym: "first trimester" RELATED [http://en.wikipedia.org/wiki/Gestational_age]
 is_a: HsapDv:0000000 ! life cycle stage
-relationship: part_of HsapDv:0000045 ! prenatal stage
+relationship: part_of HsapDv:0000045 ! prenatal stagef
 property_value: start_dpf "0.0" xsd:float
 property_value: end_dpf "56.0" xsd:float
 xref: HP:0011460

--- a/src/ontology/components/hsapdv.obo
+++ b/src/ontology/components/hsapdv.obo
@@ -2217,7 +2217,7 @@ def: "Adult stage that refers to an adult who is over 40 and under 41 years old.
 subset: granular_stage
 xref: EV:0300093
 is_a: HsapDv:0000000 ! life cycle stage
-relationship: part_of HsapDv:0000239 ! fifth decade stage
+relationship: part_of HsapDv:0000239 ! fourth decade stage
 relationship: immediately_preceded_by HsapDv:0000133 ! 39-year-old stage
 
 [Term]
@@ -2383,7 +2383,7 @@ def: "Middle aged stage that refers to an adult who is over 50 and under 51 year
 subset: granular_stage
 xref: EV:0300103
 is_a: HsapDv:0000000 ! life cycle stage
-relationship: part_of HsapDv:0000240 ! sixth decade stage
+relationship: part_of HsapDv:0000240 ! fifth decade stage
 relationship: immediately_preceded_by HsapDv:0000143 ! 49-year-old stage
 
 [Term]
@@ -3303,11 +3303,11 @@ property_value: start_ypb "30.0" xsd:float
 id: HsapDv:0000239
 name: fifth decade stage
 namespace: human_developmental_stage
-def: "Human stage that refers to an individual who is over 40 and less than or equal to 50 years old." [Bgee:curator]
+def: "Human stage that refers to an individual who is at least 41 and less than 51 years old." [Bgee:curator]
 is_a: HsapDv:0000000 ! life cycle stage
 relationship: immediately_preceded_by HsapDv:0000238 ! fourth decade stage
 relationship: part_of HsapDv:0000267 ! middle aged stage
-property_value: end_ypb "50.0" xsd:float
+property_value: end_ypb "50.9" xsd:float
 property_value: start_ypb "41.0" xsd:float
 
 [Term]


### PR DESCRIPTION
The current definition of a decade, say fifth decade stage, states over 40 and under 50, which excludes both of these ages. Change so that the fifth decade stage begins at the beginning of age 41 and ends at the end of age 50. (It could be end of 40 to beginning of 50 - but in any event the decade designation should include the decade digit + zero.) If this argument is valid, each decade def needs to change and the decade-assignment of the zero years needs to be assessed to the revised decade delimiters.